### PR TITLE
Clarify mobile workflow and add CLI server options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Mesh Editor Prototype
+
+This prototype boots a lightweight 3D engine that now supports both a desktop
+pygame shell and a mobile-friendly web viewer.
+
+## Desktop experience
+
+Run the default desktop experience (requires `pygame`):
+
+```bash
+python main.py
+```
+
+## Mobile web viewer
+
+The mobile viewer exposes the engine state over HTTP and renders the default
+scene in a responsive Three.js view that works well on Android browsers.
+
+1. Install Flask if it is not already available:
+   ```bash
+   pip install flask
+   ```
+2. Connect your development machine and Android phone to the same Wi-Fi
+   network. This allows the phone to reach the local server.
+3. Start the application in mobile mode. You can optionally control the bind
+   address and port directly from the command line:
+   ```bash
+   python main.py --mobile --host 0.0.0.0 --port 5000
+   ```
+   The server prints both the bind address and a "shareable" address that you
+   can open on another device. If you already know your computer's LAN IP, you
+   can pass it with `--host` (for example `--host 192.168.1.10`).
+4. On your Android device, open the printed URL in Chrome or Firefox. If the
+   page does not load, double-check that the phone is on the same network and
+   that the desktop firewall allows incoming connections on the chosen port.
+5. Use the on-screen instructions to orbit, pan, or zoom the model.
+
+You can also force mobile mode without the command-line flag by setting an
+environment variable:
+
+```bash
+export MESH_EDITOR_FORCE_MOBILE=1
+python main.py
+```
+
+By default the server listens on all interfaces (`0.0.0.0`) and port `5000`.
+Override these defaults with the `--host`/`--port` flags or the environment
+variables `MESH_EDITOR_MOBILE_HOST` and `MESH_EDITOR_MOBILE_PORT` when needed.
+
+### Smoke-testing the mobile server
+
+After starting the server you can confirm that it is running by fetching the
+scene payload from the same machine:
+
+```bash
+curl http://127.0.0.1:5000/api/scene
+```
+
+The command should print a JSON document describing the meshes and active
+camera. If you have trouble reaching the endpoint locally, resolve that issue
+before attempting to connect from your phone.
+
+## Notes
+
+- The mobile viewer currently streams a snapshot of meshes that exist when the
+  server starts. Use the **Refresh scene** button in the UI to fetch the latest
+  data.
+- Advanced modeling features remain desktop-only while the mobile workflow
+  focuses on reviewing and light navigation of the scene.

--- a/main.py
+++ b/main.py
@@ -1,28 +1,64 @@
+import argparse
 import os
 import sys
 from core.engine import Engine
-from ui.desktop.desktop_app import DesktopApp
-from ui.mobile.mobile_app import MobileApp
 
 
-def main():
+def main(argv=None):
+    """Entry point that launches either the desktop or mobile experience."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
     # Initialize the core engine
     engine = Engine()
     engine.initialize()  # Initialize with default objects
 
     # Detect platform and launch appropriate UI
-    if is_mobile():
-        app = MobileApp(engine)
+    use_mobile = args.mobile or is_mobile()
+
+    if use_mobile:
+        # Lazy import so we do not require the pygame dependency when using the
+        # mobile web experience.
+        try:
+            from ui.mobile.mobile_app import MobileApp
+        except RuntimeError as exc:
+            print(exc)
+            return 1
+        app = MobileApp(engine, host=args.host, port=args.port)
     else:
+        from ui.desktop.desktop_app import DesktopApp
         app = DesktopApp(engine)
 
     app.run()
+    return 0
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(description="Launch the mesh editor.")
+    parser.add_argument(
+        "--mobile",
+        action="store_true",
+        help="Start the Flask-based mobile viewer instead of the desktop app.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Hostname or IP address for the mobile server (defaults to 0.0.0.0).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port for the mobile server (defaults to 5000).",
+    )
+    return parser.parse_args(argv)
 
 
 def is_mobile():
-    # Simple platform detection - can be enhanced
-    return 'ANDROID_STORAGE' in os.environ
+    """Determine whether to launch the mobile experience."""
+    if os.environ.get("MESH_EDITOR_FORCE_MOBILE", "").lower() in {"1", "true", "yes"}:
+        return True
+    return "ANDROID_STORAGE" in os.environ
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/ui/mobile/mobile_app.py
+++ b/ui/mobile/mobile_app.py
@@ -1,8 +1,118 @@
+import os
+import socket
+from datetime import datetime
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+
 
 class MobileApp:
-    def __init__(self, engine):
-        self.engine = engine
+    """Serve a lightweight web viewer that works on mobile devices."""
 
-    def run(self):
-        """Start the mobile application"""
-        print("Mobile app not implemented yet")
+    def __init__(self, engine, host: Optional[str] = None, port: Optional[int] = None):
+        self.engine = engine
+        self.host = host or os.environ.get("MESH_EDITOR_MOBILE_HOST", "0.0.0.0")
+        self.port = int(port or os.environ.get("MESH_EDITOR_MOBILE_PORT", 5000))
+
+        try:
+            from flask import Flask, jsonify, render_template
+        except ImportError as exc:  # pragma: no cover - depends on runtime env
+            raise RuntimeError(
+                "The mobile viewer requires Flask. Install it with 'pip install flask'."
+            ) from exc
+
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        template_dir = os.path.join(base_dir, "templates")
+        static_dir = os.path.join(base_dir, "static")
+
+        self._jsonify = jsonify
+        self._render_template = render_template
+        self._app = Flask(
+            __name__,
+            template_folder=template_dir,
+            static_folder=static_dir,
+            static_url_path="/static",
+        )
+        self._register_routes()
+
+    def run(self) -> None:
+        """Start the Flask development server."""
+        local_ip = self._guess_local_ip() if self.host in {"0.0.0.0", "::"} else self.host
+        print("\nMobile viewer ready!\n")
+        print(f"Local server: http://{self.host}:{self.port}")
+        if local_ip and local_ip != self.host:
+            print("Ensure your phone is on the same network, then open:")
+            print(f"  http://{local_ip}:{self.port}")
+        print("Press CTRL+C to stop the server.\n")
+
+        self._app.run(host=self.host, port=self.port, debug=False, use_reloader=False)
+
+    # ------------------------------------------------------------------
+    # Flask routes
+    # ------------------------------------------------------------------
+    def _register_routes(self) -> None:
+        @self._app.route("/")
+        def index():
+            return self._render_template(
+                "index.html",
+                scene_name=self.engine.scene.root.name,
+                now=datetime.utcnow().strftime("%Y-%m-%d %H:%M:%SZ"),
+            )
+
+        @self._app.route("/api/scene")
+        def api_scene():
+            return self._jsonify(self._build_scene_payload())
+
+    # ------------------------------------------------------------------
+    # Scene serialization helpers
+    # ------------------------------------------------------------------
+    def _build_scene_payload(self) -> Dict[str, object]:
+        from core.mesh import Mesh
+
+        meshes: List[Dict[str, object]] = []
+        for obj in self.engine.scene.root.children:
+            if isinstance(obj, Mesh):
+                meshes.append(
+                    {
+                        "name": obj.name,
+                        "vertices": obj.vertices.astype(float).tolist(),
+                        "faces": [list(face) for face in obj.faces],
+                        "transform": {
+                            "position": obj.transform.position.astype(float).tolist(),
+                            "rotation": obj.transform.rotation.astype(float).tolist(),
+                            "scale": obj.transform.scale.astype(float).tolist(),
+                        },
+                    }
+                )
+
+        camera = self.engine.scene.active_camera
+        camera_payload = None
+        if camera is not None:
+            camera_payload = {
+                "name": getattr(camera, "name", "Camera"),
+                "transform": {
+                    "position": self._to_list(camera.transform.position),
+                    "rotation": self._to_list(camera.transform.rotation),
+                },
+            }
+
+        return {
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "meshes": meshes,
+            "camera": camera_payload,
+        }
+
+    @staticmethod
+    def _to_list(value: Union[np.ndarray, List[float]]) -> List[float]:
+        if isinstance(value, np.ndarray):
+            return value.astype(float).tolist()
+        return list(value)
+
+    @staticmethod
+    def _guess_local_ip() -> str:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(("8.8.8.8", 80))
+                return sock.getsockname()[0]
+        except OSError:
+            return "localhost"

--- a/ui/mobile/static/styles.css
+++ b/ui/mobile/static/styles.css
@@ -1,0 +1,124 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 1.25rem 1.5rem 0.5rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(16, 185, 129, 0.35));
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+main {
+  flex: 1;
+  padding: 1rem 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.viewer-wrapper {
+  position: relative;
+  width: 100%;
+  flex: 1;
+  min-height: 360px;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+#viewer {
+  width: 100%;
+  height: 100%;
+}
+
+#loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.85);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.instructions {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  line-height: 1.5;
+}
+
+.instructions h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.instructions ol {
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #38bdf8, #22c55e);
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+button:not(:disabled):active {
+  transform: scale(0.97);
+}
+
+footer {
+  padding: 1rem 1.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.5);
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+@media (min-width: 900px) {
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .viewer-wrapper {
+    min-height: 480px;
+  }
+}

--- a/ui/mobile/templates/index.html
+++ b/ui/mobile/templates/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ scene_name }} – Mobile Viewer</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Mesh Viewer</h1>
+      <p class="subtitle">Interactive preview optimised for mobile browsers.</p>
+    </header>
+
+    <main>
+      <section class="viewer-wrapper">
+        <div id="viewer"></div>
+        <div id="loading" role="status">Loading scene…</div>
+      </section>
+
+      <section class="instructions">
+        <h2>How to use</h2>
+        <ol>
+          <li>Drag with one finger to orbit around the model.</li>
+          <li>Drag with two fingers to pan the camera.</li>
+          <li>Pinch with two fingers to zoom in or out.</li>
+          <li>Tap the refresh button below if you update the desktop scene.</li>
+        </ol>
+        <button id="refresh">Refresh scene</button>
+      </section>
+    </main>
+
+    <footer>
+      <small>Served from {{ scene_name }} at {{ now }}.</small>
+    </footer>
+
+    <script type="module">
+      import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.158/build/three.module.js";
+      import { OrbitControls } from "https://cdn.jsdelivr.net/npm/three@0.158/examples/jsm/controls/OrbitControls.js";
+
+      const viewer = document.getElementById("viewer");
+      const loading = document.getElementById("loading");
+      const refreshButton = document.getElementById("refresh");
+
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+      viewer.appendChild(renderer.domElement);
+
+      const scene = new THREE.Scene();
+      scene.background = new THREE.Color(0x111827);
+
+      const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
+      camera.position.set(4, 3, 6);
+
+      const controls = new OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+      controls.dampingFactor = 0.08;
+      controls.enablePan = true;
+      controls.minDistance = 1;
+      controls.maxDistance = 40;
+
+      const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+      scene.add(ambientLight);
+
+      const keyLight = new THREE.DirectionalLight(0xffffff, 0.8);
+      keyLight.position.set(5, 10, 7);
+      scene.add(keyLight);
+
+      const rimLight = new THREE.DirectionalLight(0x7dd3fc, 0.3);
+      rimLight.position.set(-4, 6, -6);
+      scene.add(rimLight);
+
+      const grid = new THREE.GridHelper(20, 20, 0x4ade80, 0x1f2937);
+      grid.material.opacity = 0.35;
+      grid.material.transparent = true;
+      grid.position.y = -0.5;
+      scene.add(grid);
+
+      let meshGroup = new THREE.Group();
+      scene.add(meshGroup);
+
+      async function loadScene() {
+        loading.hidden = false;
+        refreshButton.disabled = true;
+
+        try {
+          const response = await fetch("/api/scene");
+          if (!response.ok) {
+            throw new Error(`Failed to load scene: ${response.status}`);
+          }
+          const data = await response.json();
+          rebuildScene(data);
+        } catch (error) {
+          loading.textContent = error.message;
+          console.error(error);
+        } finally {
+          refreshButton.disabled = false;
+          if (meshGroup.children.length > 0) {
+            setTimeout(() => {
+              loading.hidden = true;
+              loading.textContent = "Loading scene…";
+            }, 300);
+          }
+        }
+      }
+
+      function rebuildScene(data) {
+        meshGroup.clear();
+
+        let hasGeometry = false;
+        (data.meshes || []).forEach((meshData) => {
+          const geometry = new THREE.BufferGeometry();
+          const positions = meshData.vertices.flat();
+          const indices = [];
+
+          meshData.faces.forEach((face) => {
+            if (face.length === 3) {
+              indices.push(face[0], face[1], face[2]);
+            } else if (face.length === 4) {
+              indices.push(face[0], face[1], face[2], face[0], face[2], face[3]);
+            }
+          });
+
+          geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+          if (indices.length > 0) {
+            geometry.setIndex(indices);
+          }
+          geometry.computeVertexNormals();
+
+          const material = new THREE.MeshStandardMaterial({
+            color: 0x60a5fa,
+            roughness: 0.45,
+            metalness: 0.1,
+          });
+
+          const wireframe = new THREE.LineSegments(
+            new THREE.EdgesGeometry(geometry),
+            new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 0.3, transparent: true })
+          );
+
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.position.fromArray(meshData.transform.position);
+          mesh.rotation.set(
+            meshData.transform.rotation[0],
+            meshData.transform.rotation[1],
+            meshData.transform.rotation[2]
+          );
+          mesh.scale.fromArray(meshData.transform.scale);
+
+          wireframe.position.copy(mesh.position);
+          wireframe.rotation.copy(mesh.rotation);
+          wireframe.scale.copy(mesh.scale);
+
+          meshGroup.add(mesh);
+          meshGroup.add(wireframe);
+          hasGeometry = true;
+        });
+
+        if (data.camera && data.camera.transform) {
+          const pos = data.camera.transform.position;
+          camera.position.set(pos[0], pos[1], pos[2]);
+          controls.target.set(0, 0, 0);
+          controls.update();
+        }
+
+        if (!hasGeometry) {
+          loading.hidden = false;
+          loading.textContent = "No meshes available yet.";
+        }
+      }
+
+      function onWindowResize() {
+        const { clientWidth, clientHeight } = viewer;
+        camera.aspect = clientWidth / clientHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(clientWidth, clientHeight);
+      }
+
+      refreshButton.addEventListener("click", loadScene);
+      window.addEventListener("resize", onWindowResize);
+
+      function animate() {
+        requestAnimationFrame(animate);
+        controls.update();
+        renderer.render(scene, camera);
+      }
+
+      onWindowResize();
+      loadScene();
+      animate();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an argparse-based launcher that exposes --mobile, --host, and --port flags for the Flask viewer
- expand the README with step-by-step Android connection guidance and a curl smoke test
- print an explicit reminder about using the same network when sharing the local IP address

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68de074d7d388327bec6953f474984e4