### PR TITLE
Replace PWA icons with editable SVG assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ before attempting to connect from your phone.
   data.
 - Advanced modeling features remain desktop-only while the mobile workflow
   focuses on reviewing and light navigation of the scene.
+
+## Installable PWA (offline-ready)
+
+The repository also ships an installable Progressive Web App located in
+[`pwa/`](pwa/) that runs entirely client-side. You can deploy it as static
+files (for example with GitHub Pages or Netlify) and then install it on Android
+via **Add to Home Screen**.
+
+1. Serve the directory locally to test:
+   ```bash
+   python -m http.server --directory pwa 5173
+   ```
+   Then open `http://127.0.0.1:5173` in your browser.
+2. The app registers a service worker that pre-caches the shell and caches
+   Three.js modules on first load, making the viewer available offline after it
+   has been opened once.
+3. To deploy, copy the contents of `pwa/` to any static host. The installable
+   icons are shipped as SVG files so they remain editable without binary assets.

--- a/pwa/icon-192.svg
+++ b/pwa/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="40" fill="#0f172a" />
+  <path d="M144 136 96 160 48 136V88l48-24 48 24z" fill="url(#g)" stroke="#0ea5e9" stroke-width="6" stroke-linejoin="round" />
+  <path d="M96 56 64 72l32 16 32-16z" fill="#0ea5e9" opacity="0.5" />
+</svg>

--- a/pwa/icon-512.svg
+++ b/pwa/icon-512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="#0f172a" />
+  <path d="M384 360 256 424 128 360V232l128-64 128 64z" fill="url(#g)" stroke="#0ea5e9" stroke-width="16" stroke-linejoin="round" />
+  <path d="M256 152 176 192l80 40 80-40z" fill="#0ea5e9" opacity="0.5" />
+</svg>

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Mesh Editor Mobile</title>
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#0f172a">
+  <style>
+    :root{color-scheme:dark;background:#0f172a;color:#f8fafc;font-family:Inter,system-ui,Segoe UI,sans-serif}
+    body{margin:0;display:flex;flex-direction:column;min-height:100vh}
+    header,footer{padding:12px 16px;border-bottom:1px solid #213046} footer{border-top:1px solid #213046;border-bottom:none;margin-top:auto;opacity:.75}
+    main{padding:12px;display:flex;flex-direction:column;gap:12px}
+    #viewer{width:100%;height:60vh;min-height:340px;border-radius:12px;border:1px solid #213046;overflow:hidden}
+    button{appearance:none;border:0;border-radius:999px;padding:.6rem 1.1rem;font-weight:700;background:linear-gradient(135deg,#38bdf8,#22c55e);color:#0f172a;cursor:pointer}
+    input[type="file"]{margin-left:12px}
+  </style>
+</head>
+<body>
+<header><strong>Mesh Editor (PWA)</strong></header>
+<main>
+  <div>
+    <button id="loadSample">Load sample cube</button>
+    <input id="file" type="file" accept=".json,.obj" />
+  </div>
+  <div id="viewer"></div>
+</main>
+<footer><small>Offline-capable. Add to Home Screen to install.</small></footer>
+
+<script type="module">
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.158/build/three.module.js";
+import { OrbitControls } from "https://cdn.jsdelivr.net/npm/three@0.158/examples/jsm/controls/OrbitControls.js";
+import { OBJLoader } from "https://cdn.jsdelivr.net/npm/three@0.158/examples/jsm/loaders/OBJLoader.js";
+
+const viewer = document.getElementById("viewer");
+const fileInput = document.getElementById("file");
+const loadSample = document.getElementById("loadSample");
+
+const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:true });
+renderer.setPixelRatio(devicePixelRatio);
+renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+viewer.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene(); scene.background = new THREE.Color(0x111827);
+const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth/viewer.clientHeight, 0.1, 5000);
+camera.position.set(4,3,6);
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true; controls.dampingFactor=.08;
+
+scene.add(new THREE.AmbientLight(0xffffff,.7));
+const d1 = new THREE.DirectionalLight(0xffffff,.9); d1.position.set(5,10,7); scene.add(d1);
+
+const group = new THREE.Group(); scene.add(group);
+
+function resize(){
+  const w = viewer.clientWidth, h = viewer.clientHeight;
+  camera.aspect = w/h; camera.updateProjectionMatrix(); renderer.setSize(w,h);
+}
+addEventListener("resize", resize);
+
+function frame(){
+  const box = new THREE.Box3().setFromObject(group);
+  if(!box.isEmpty()){
+    const size = box.getSize(new THREE.Vector3()), center = box.getCenter(new THREE.Vector3());
+    const maxDim = Math.max(size.x,size.y,size.z)||1;
+    const dist = maxDim / (2*Math.tan(THREE.MathUtils.degToRad(camera.fov/2))) * 1.2;
+    camera.position.copy(center.clone().add(new THREE.Vector3(dist, dist*0.6, dist)));
+    controls.target.copy(center); controls.update();
+  }
+}
+
+function clear(){ while(group.children.length) group.remove(group.children[0]); }
+
+function loadSceneJSON(data){
+  clear();
+  (data.meshes||[]).forEach(md=>{
+    const positions = md.vertices.flat();
+    const indices = [];
+    (md.faces||[]).forEach(f=>{ if(f.length===3){indices.push(...f)} else if(f.length===4){indices.push(f[0],f[1],f[2], f[0],f[2],f[3])} });
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", new THREE.Float32BufferAttribute(positions,3));
+    if(indices.length) g.setIndex(indices);
+    g.computeVertexNormals();
+    const m = new THREE.MeshStandardMaterial({ roughness:.45, metalness:.1 });
+    const mesh = new THREE.Mesh(g,m);
+    const t=md.transform||{}, p=t.position||[0,0,0], r=t.rotation||[0,0,0], s=t.scale||[1,1,1];
+    mesh.position.set(...p); mesh.rotation.set(...r); mesh.scale.set(...s);
+    group.add(mesh);
+  });
+  frame();
+}
+
+function loadOBJText(text){
+  clear();
+  const loader = new OBJLoader();
+  const obj = loader.parse(text);
+  obj.traverse(c=>{ if(c.isMesh){ c.material = new THREE.MeshStandardMaterial({roughness:.5, metalness:.05}); group.add(c); } });
+  frame();
+}
+
+fileInput.addEventListener("change", async e=>{
+  const f = e.target.files?.[0]; if(!f) return;
+  const text = await f.text();
+  if(f.name.toLowerCase().endsWith(".obj")) loadOBJText(text);
+  else loadSceneJSON(JSON.parse(text));
+});
+
+loadSample.addEventListener("click", ()=>{
+  loadSceneJSON({
+    version:1,
+    meshes:[{ name:"Cube",
+      vertices:[[ -1,-1, 1],[ 1,-1, 1],[ 1, 1, 1],[ -1, 1, 1],[ -1,-1,-1],[ 1,-1,-1],[ 1, 1,-1],[ -1, 1,-1]],
+      faces:[[0,1,2,3],[1,5,6,2],[5,4,7,6],[4,0,3,7],[3,2,6,7],[4,5,1,0]],
+      transform:{ position:[0,0,0], rotation:[0,0,0], scale:[1,1,1] }
+    }]
+  });
+});
+
+function animate(){ requestAnimationFrame(animate); controls.update(); renderer.render(scene,camera); }
+resize(); animate();
+
+if('serviceWorker' in navigator) navigator.serviceWorker.register('./service-worker.js');
+</script>
+</body>
+</html>

--- a/pwa/manifest.json
+++ b/pwa/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mesh Editor Mobile",
+  "short_name": "MeshEditor",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    { "src": "icon-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any" },
+    { "src": "icon-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any" }
+  ]
+}

--- a/pwa/service-worker.js
+++ b/pwa/service-worker.js
@@ -1,0 +1,54 @@
+const CACHE = "mesh-editor-v2";
+const ASSETS = [
+  "./",
+  "./index.html",
+  "./manifest.json",
+  "./icon-192.svg",
+  "./icon-512.svg"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          const url = new URL(event.request.url);
+
+          // Cache same-origin assets as well as CDN dependencies that allow caching.
+          if (response.ok && (url.origin === location.origin || url.hostname.endsWith("jsdelivr.net"))) {
+            caches.open(CACHE).then((cache) => cache.put(event.request, copy));
+          }
+
+          return response;
+        })
+        .catch(() => {
+          if (event.request.mode === "navigate") {
+            return caches.match("./index.html");
+          }
+        });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- replace the binary PNG PWA icons with equivalent SVG artwork that can live in git as text
- point the manifest and service worker at the new SVG assets and refresh the cache key
- note in the README that the icons are SVGs to keep the PWA deployable without binary files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de250e284083279b51ac4787501918